### PR TITLE
Update BMIQ_1.1.R

### DIFF
--- a/R/BMIQ_1.1.R
+++ b/R/BMIQ_1.1.R
@@ -270,7 +270,9 @@ p.v <- pbeta(beta2.v[selMR.idx],em2.o$a[lt,1],em2.o$b[lt,1],lower.tail=FALSE);
 q.v <- qbeta(p.v,em1.o$a[lt,1],em1.o$b[lt,1],lower.tail=FALSE);
 nbeta2.v[selMR.idx] <- q.v;
 
-
+## initializing the dilation factor
+hf <- NULL
+   
 if(doH){ ### if TRUE also correct type2 hemimethylated probes
 ### select H probes and include ML probes (left ML tail is not well described by a beta-distribution).
 lt <- 2;


### PR DESCRIPTION
Initializing hf before its use since if doH=FALSE, this variable won't exist and therefore the function will crash when we try to assign hf to the list of the return values. With the current modification, if doH=FALSE, the function won't crash and in the end hf will just return as NULL.